### PR TITLE
Add the Defaults for the new Structs

### DIFF
--- a/internal/apis/configuration/v1alpha1/defaults.go
+++ b/internal/apis/configuration/v1alpha1/defaults.go
@@ -16,180 +16,220 @@ limitations under the License.
 
 package v1alpha1
 
+import (
+	"net"
+	"runtime"
+	"time"
+)
+
 const (
-	// http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
-	// Sets the maximum allowed size of the client request body
-	bodySize = "1m"
-
-	// http://nginx.org/en/docs/ngx_core_module.html#error_log
-	// Configures logging level [debug | info | notice | warn | error | crit | alert | emerg]
-	// Log levels above are listed in the order of increasing severity
-	errorLevel = "notice"
-
-	// HTTP Strict Transport Security (often abbreviated as HSTS) is a security feature (HTTP header)
-	// that tell browsers that it should only be communicated with using HTTPS, instead of using HTTP.
-	// https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security
-	// max-age is the time, in seconds, that the browser should remember that this site is only to be accessed using HTTPS.
-	hstsMaxAge = "15724800"
-
-	gzipTypes = "application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component"
-
-	brotliTypes = "application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component"
-
+	gzipTypes         = "application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component"
+	brotliTypes       = "application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component"
 	logFormatUpstream = `%v - [$the_real_ip] - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id`
-
-	logFormatStream = `[$time_local] $protocol $status $bytes_sent $bytes_received $session_time`
-
-	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_buffer_size
-	// Sets the size of the buffer used for sending data.
-	// 4k helps NGINX to improve TLS Time To First Byte (TTTFB)
-	// https://www.igvita.com/2013/12/16/optimizing-nginx-tls-time-to-first-byte/
-	sslBufferSize = "4k"
 
 	// Enabled ciphers list to enabled. The ciphers are specified in the format understood by the OpenSSL library
 	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ciphers
 	sslCiphers = "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
-
-	// SSL enabled protocols to use
-	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols
-	sslProtocols = "TLSv1.2"
-
-	// Time during which a client may reuse the session parameters stored in a cache.
-	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout
-	sslSessionTimeout = "10m"
-
-	// Size of the SSL shared cache between all worker processes.
-	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache
-	sslSessionCacheSize = "10m"
-
-	// Default setting for load balancer algorithm
-	defaultLoadBalancerAlgorithm = ""
-
-	// Parameters for a shared memory zone that will keep states for various keys.
-	// http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone
-	defaultLimitConnZoneVariable = "$binary_remote_addr"
 )
 
-/*
 // NewDefaultConfiguration returns the default nginx configuration
 func NewDefaultConfiguration() ConfigurationSpec {
-	defIPCIDR := make([]string, 0)
-	defBindAddress := make([]string, 0)
-	defNginxStatusIpv4Whitelist := make([]string, 0)
-	defNginxStatusIpv6Whitelist := make([]string, 0)
 
-	defIPCIDR = append(defIPCIDR, "0.0.0.0/0")
-	defNginxStatusIpv4Whitelist = append(defNginxStatusIpv4Whitelist, "127.0.0.1")
-	defNginxStatusIpv6Whitelist = append(defNginxStatusIpv6Whitelist, "::1")
-	defProxyDeadlineDuration := time.Duration(5) * time.Second
+	defIPCIDR := make([]net.IPAddr, 0)
+	defBindAddress := make([]net.IPAddr, 0)
+	localhost := net.IPAddr{IP: net.ParseIP("127.0.0.1")}
+	defNginxStatusIpv4Whitelist := []net.IPAddr{localhost}
 
-	cfg := Configuration{
-		AllowBackendServerHeader:   false,
-		AccessLogPath:              "/var/log/nginx/access.log",
-		WorkerCpuAffinity:          "",
-		ErrorLogPath:               "/var/log/nginx/error.log",
+	loadBalancer := LoadBalanceAlgorithm(RoundRobin)
+	jaegerSamplerType := JaegerSamplerType(ConstJaegerSampler)
+
+	global := &Global{
+		BindAddressIpv4:            defBindAddress,
+		BindAddressIpv6:            defBindAddress,
+		CustomHTTPErrors:           []int{},
+		EnableBrotli:               false,
 		BrotliLevel:                4,
 		BrotliTypes:                brotliTypes,
-		ClientHeaderBufferSize:     "1k",
-		ClientHeaderTimeout:        60,
-		ClientBodyBufferSize:       "8k",
-		ClientBodyTimeout:          60,
-		EnableDynamicTLSRecords:    true,
-		EnableUnderscoresInHeaders: false,
-		ErrorLogLevel:              errorLevel,
-		ForwardedForHeader:         "X-Forwarded-For",
-		ComputeFullForwardedFor:    false,
-		ProxyAddOriginalUriHeader:  true,
-		GenerateRequestId:          true,
-		HTTP2MaxFieldSize:          "4k",
-		HTTP2MaxHeaderSize:         "16k",
-		HTTPRedirectCode:           308,
-		HSTS:                       true,
-		HSTSIncludeSubdomains:      true,
-		HSTSMaxAge:                 hstsMaxAge,
-		HSTSPreload:                false,
-		IgnoreInvalidHeaders:       true,
+		EnableGeoIP:                true,
+		EnableGzip:                 true,
 		GzipLevel:                  5,
 		GzipTypes:                  gzipTypes,
+		EnableInfluxDB:             false,
+		EnableIPV6:                 true,
+		EnableIPV6DNS:              true,
+		EnableMultiAccept:          true,
+		EnableProxyProtocol:        false,
+		EnableRequestID:            true,
+		EnableReusePort:            true,
+		EnableUnderscoresInHeaders: false,
+		IgnoreInvalidHeaders:       true,
+		WorkerCPUAffinity:          "",
 		KeepAlive:                  75,
 		KeepAliveRequests:          100,
-		LargeClientHeaderBuffers:   "4 8k",
-		LogFormatEscapeJSON:        false,
-		LogFormatStream:            logFormatStream,
-		LogFormatUpstream:          logFormatUpstream,
-		EnableMultiAccept:          true,
-		MaxWorkerConnections:       16384,
+		LimitConnZoneVariable:      "$binary_remote_addr",
+		LimitRequestStatusCode:     429,
+		LoadBalanceAlgorithm:       &loadBalancer,
 		MapHashBucketSize:          64,
-		NginxStatusIpv4Whitelist:   defNginxStatusIpv4Whitelist,
-		NginxStatusIpv6Whitelist:   defNginxStatusIpv6Whitelist,
-		ProxyRealIPCIDR:            defIPCIDR,
-		ProxyProtocolHeaderTimeout: defProxyDeadlineDuration,
-		ServerNameHashMaxSize:      1024,
-		ProxyHeadersHashMaxSize:    512,
+		MaxWorkerConnections:       16384,
 		ProxyHeadersHashBucketSize: 64,
-		ProxyStreamResponses:       1,
-		ReusePort:                  true,
-		ShowServerTokens:           true,
-		SSLBufferSize:              sslBufferSize,
-		SSLCiphers:                 sslCiphers,
-		SSLECDHCurve:               "auto",
-		SSLProtocols:               sslProtocols,
-		SSLSessionCache:            true,
-		SSLSessionCacheSize:        sslSessionCacheSize,
-		SSLSessionTickets:          true,
-		SSLSessionTimeout:          sslSessionTimeout,
-		EnableBrotli:               false,
-		UseGzip:                    true,
-		UseGeoIP:                   true,
-		WorkerProcesses:            strconv.Itoa(runtime.NumCPU()),
-		WorkerShutdownTimeout:      "10s",
-		LoadBalanceAlgorithm:       defaultLoadBalancerAlgorithm,
-		VariablesHashBucketSize:    128,
-		VariablesHashMaxSize:       2048,
-		UseHTTP2:                   true,
-		ProxyStreamTimeout:         "600s",
-		Backend: defaults.Backend{
-			ProxyBodySize:          bodySize,
-			ProxyConnectTimeout:    5,
-			ProxyReadTimeout:       60,
-			ProxySendTimeout:       60,
-			ProxyBufferSize:        "4k",
-			ProxyCookieDomain:      "off",
-			ProxyCookiePath:        "off",
-			ProxyNextUpstream:      "error timeout",
-			ProxyNextUpstreamTries: 3,
-			ProxyRequestBuffering:  "on",
-			ProxyRedirectFrom:      "off",
-			ProxyRedirectTo:        "off",
-			SSLRedirect:            true,
-			CustomHTTPErrors:       []int{},
-			WhitelistSourceRange:   []string{},
-			SkipAccessLogURLs:      []string{},
-			LimitRate:              0,
-			LimitRateAfter:         0,
-			ProxyBuffering:         "off",
-		},
-		UpstreamKeepaliveConnections: 32,
-		LimitConnZoneVariable:        defaultLimitConnZoneVariable,
-		BindAddressIpv4:              defBindAddress,
-		BindAddressIpv6:              defBindAddress,
-		ZipkinCollectorPort:          9411,
-		ZipkinServiceName:            "nginx",
-		ZipkinSampleRate:             1.0,
-		JaegerCollectorPort:          6831,
-		JaegerServiceName:            "nginx",
-		JaegerSamplerType:            "const",
-		JaegerSamplerParam:           "1",
-		LimitReqStatusCode:           503,
-		SyslogPort:                   514,
-		NoTLSRedirectLocations:       "/.well-known/acme-challenge",
-		NoAuthLocations:              "/.well-known/acme-challenge",
+		ProxyHeadersHashMaxSize:    512,
+		ProxyProtocolHeaderTimeout: time.Duration(5) * time.Second,
+		ProxyRealIPCIDR:            defIPCIDR,
+		//Resolver: ,
+		RetryNonIdempotent: false,
+		//ServerNameHashBucketSize: ,
+		ServerNameHashMaxSize: 1024,
+		ShowServerTokens:      true,
+		StatusIPV4Whitelist:   defNginxStatusIpv4Whitelist,
+		//StatusIPV6Whitelist: defNginxStatusIpv6Whitelist,
+		WorkerProcesses:       runtime.NumCPU(),
+		WorkerShutdownTimeout: time.Duration(10) * time.Second,
+		//VariablesHashBucketSize: ,
+		VariablesHashMaxSize:    2048,
+		ForwardedForHeader:      "X-Forwarded-For",
+		ComputeFullForwardedFor: false,
+		HTTPRedirectCode:        308,
+		NoAuthLocations:         "",
+		PortInRedirects:         false,
+		//WhitelistSourceRange: ,
 	}
 
-	if glog.V(5) {
-		cfg.ErrorLogLevel = "debug"
+	client := &Client{
+		BodyBufferSize:           "8k",
+		BodyTimeout:              60,
+		HeaderBufferSize:         "1k",
+		HeaderTimeout:            60,
+		LargeClientHeaderBuffers: "4 8k",
+	}
+
+	http2 := &HTTP2{
+		Enabled:       true,
+		MaxFieldSize:  "4k",
+		MaxHeaderSize: "16k",
+	}
+
+	file := &LogFileConfiguration{
+		AccessLogPath: "/var/log/nginx/access.log",
+		ErrorLogPath:  "/var/log/nginx/error.log",
+	}
+
+	syslog := &SyslogConfiguration{
+		Enabled: false,
+		Host:    "",
+		Port:    514,
+	}
+
+	log := &Log{
+		EnableAccessLog:   true,
+		ErrorLogLevel:     "notice",
+		FormatEscapeJSON:  false,
+		FormatUpstream:    logFormatUpstream,
+		SkipAccessLogURLs: []string{},
+		File:              file,
+		Syslog:            syslog,
+	}
+
+	metrics := &Metrics{
+		Enabled:        false,
+		Latency:        []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		ResponseLength: []float64{100, 1000, 10000, 100000, 1000000},
+		RequestLength:  []float64{1000, 10000, 100000, 1000000, 10000000},
+	}
+
+	snippets := &Snippets{
+		Main:     "",
+		HTTP:     "",
+		Server:   "",
+		Location: "",
+	}
+
+	hsts := &HSTS{
+		Enabled:           true,
+		IncludeSubdomains: true,
+		MaxAge:            15724800,
+		Preload:           false,
+	}
+
+	ssl := &SSL{
+		HSTS:        hsts,
+		SSLRedirect: true,
+		//ForceSSLRedirect: ,
+		//NoTLSRedirectLocations:,
+		Ciphers:   sslCiphers,
+		ECDHCurve: "auto",
+		//DHParam: ,
+		Protocols:        "TLSv1.2",
+		SessionCache:     true,
+		SessionCacheSize: "10m",
+		SessionTickets:   true,
+		//SessionTicketKey: ,
+		SessionTimeout: "10m",
+		BufferSize:     "4k",
+	}
+
+	jaeger := &JaegerConfiguration{
+		CollectorHost: "",
+		CollectorPort: 6831,
+		ServiceName:   "nginx",
+		SamplerType:   jaegerSamplerType,
+		SamplerParam:  "1",
+	}
+
+	zipkin := &ZipkinConfiguration{
+		CollectorHost: "",
+		CollectorPort: 9411,
+		ServiceName:   "nginx",
+		SampleRate:    1.0,
+	}
+
+	opentracing := &Opentracing{
+		Enabled: false,
+		Jaeger:  jaeger,
+		Zipkin:  zipkin,
+	}
+
+	upstream := &Upstream{
+		AddOriginalURIHeader:          true,
+		SetHeaders:                    make(map[string]string),
+		HideHeaders:                   []string{},
+		EnableServerHeaderFromBackend: false,
+		BodySize:                      "1m",
+		Buffering:                     "off",
+		BufferSize:                    "4k",
+		CookieDomain:                  "off",
+		CookiePath:                    "off",
+		ConnectTimeout:                5,
+		FailTimeout:                   0,
+		//HashBy: "",
+		KeepaliveConnections: 32,
+		MaxFails:             0,
+		NextUpstream:         "error timeout",
+		NextUpstreamTries:    3,
+		ReadTimeout:          60,
+		RedirectFrom:         "off",
+		RedirectTo:           "off",
+		RequestBuffering:     "on",
+		SendTimeout:          60,
+	}
+
+	waf := &WAF{
+		EnableModsecurity:    false,
+		EnableOWASPCoreRules: false,
+		EnableLuaRestyWAF:    true,
+	}
+
+	cfg := ConfigurationSpec{
+		Global:      global,
+		Client:      client,
+		HTTP2:       http2,
+		Log:         log,
+		Metrics:     metrics,
+		Snippets:    snippets,
+		SSL:         ssl,
+		Opentracing: opentracing,
+		Upstream:    upstream,
+		WAF:         waf,
 	}
 
 	return cfg
 }
-*/

--- a/internal/apis/configuration/v1alpha1/types.go
+++ b/internal/apis/configuration/v1alpha1/types.go
@@ -82,7 +82,7 @@ type ConfigurationSpec struct {
 	// +optional
 	Opentracing *Opentracing `json:"opentracing,omitempty"`
 	// +optional
-	Snippets *Snippet `json:"snippets,omitempty"`
+	Snippets *Snippets `json:"snippets,omitempty"`
 	// +optional
 	SSL *SSL `json:"ssl,omitempty"`
 	// +optional
@@ -469,8 +469,8 @@ type SyslogConfiguration struct {
 	Port int `json:"port"`
 }
 
-// Snippet ...
-type Snippet struct {
+// Snippets ...
+type Snippets struct {
 	// Main adds custom configuration to the main section of the nginx configuration
 	// +optional
 	Main string `json:"main,omitempty"`

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -17,16 +17,640 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"time"
+
+	"github.com/golang/glog"
+
 	apiv1 "k8s.io/api/core/v1"
 
 	"k8s.io/ingress-nginx/internal/ingress"
+	"k8s.io/ingress-nginx/internal/ingress/defaults"
 )
 
-/*
+// TODO: Remove Configuration Object and its defaults in another CRD PR.
+const (
+	// http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
+	// Sets the maximum allowed size of the client request body
+	bodySize = "1m"
+
+	// http://nginx.org/en/docs/ngx_core_module.html#error_log
+	// Configures logging level [debug | info | notice | warn | error | crit | alert | emerg]
+	// Log levels above are listed in the order of increasing severity
+	errorLevel = "notice"
+
+	// HTTP Strict Transport Security (often abbreviated as HSTS) is a security feature (HTTP header)
+	// that tell browsers that it should only be communicated with using HTTPS, instead of using HTTP.
+	// https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security
+	// max-age is the time, in seconds, that the browser should remember that this site is only to be accessed using HTTPS.
+	hstsMaxAge = "15724800"
+
+	gzipTypes = "application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component"
+
+	brotliTypes = "application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component"
+
+	logFormatUpstream = `%v - [$the_real_ip] - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id`
+
+	logFormatStream = `[$time_local] $protocol $status $bytes_sent $bytes_received $session_time`
+
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_buffer_size
+	// Sets the size of the buffer used for sending data.
+	// 4k helps NGINX to improve TLS Time To First Byte (TTTFB)
+	// https://www.igvita.com/2013/12/16/optimizing-nginx-tls-time-to-first-byte/
+	sslBufferSize = "4k"
+
+	// Enabled ciphers list to enabled. The ciphers are specified in the format understood by the OpenSSL library
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ciphers
+	sslCiphers = "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
+
+	// SSL enabled protocols to use
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols
+	sslProtocols = "TLSv1.2"
+
+	// Time during which a client may reuse the session parameters stored in a cache.
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout
+	sslSessionTimeout = "10m"
+
+	// Size of the SSL shared cache between all worker processes.
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache
+	sslSessionCacheSize = "10m"
+
+	// Default setting for load balancer algorithm
+	defaultLoadBalancerAlgorithm = ""
+
+	// Parameters for a shared memory zone that will keep states for various keys.
+	// http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone
+	defaultLimitConnZoneVariable = "$binary_remote_addr"
+)
+
 // Configuration represents the content of nginx.conf file
 type Configuration struct {
+	defaults.Backend `json:",squash"`
 
+	// Sets the name of the configmap that contains the headers to pass to the client
+	AddHeaders string `json:"add-headers,omitempty"`
 
+	// AllowBackendServerHeader enables the return of the header Server from the backend
+	// instead of the generic nginx string.
+	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_hide_header
+	// By default this is disabled
+	AllowBackendServerHeader bool `json:"allow-backend-server-header"`
+
+	// AccessLogPath sets the path of the access logs if enabled
+	// http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log
+	// By default access logs go to /var/log/nginx/access.log
+	AccessLogPath string `json:"access-log-path,omitempty"`
+
+	// WorkerCpuAffinity bind nginx worker processes to CPUs this will improve response latency
+	// http://nginx.org/en/docs/ngx_core_module.html#worker_cpu_affinity
+	// By default this is disabled
+	WorkerCpuAffinity string `json:"worker-cpu-affinity,omitempty"`
+	// ErrorLogPath sets the path of the error logs
+	// http://nginx.org/en/docs/ngx_core_module.html#error_log
+	// By default error logs go to /var/log/nginx/error.log
+	ErrorLogPath string `json:"error-log-path,omitempty"`
+
+	// EnableDynamicTLSRecords enables dynamic TLS record sizes
+	// https://blog.cloudflare.com/optimizing-tls-over-tcp-to-reduce-latency
+	// By default this is enabled
+	EnableDynamicTLSRecords bool `json:"enable-dynamic-tls-records"`
+
+	// EnableModsecurity enables the modsecurity module for NGINX
+	// By default this is disabled
+	EnableModsecurity bool `json:"enable-modsecurity"`
+
+	// EnableModsecurity enables the OWASP ModSecurity Core Rule Set (CRS)
+	// By default this is disabled
+	EnableOWASPCoreRules bool `json:"enable-owasp-modsecurity-crs"`
+
+	// ClientHeaderBufferSize allows to configure a custom buffer
+	// size for reading client request header
+	// http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size
+	ClientHeaderBufferSize string `json:"client-header-buffer-size"`
+
+	// Defines a timeout for reading client request header, in seconds
+	// http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_timeout
+	ClientHeaderTimeout int `json:"client-header-timeout,omitempty"`
+
+	// Sets buffer size for reading client request body
+	// http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size
+	ClientBodyBufferSize string `json:"client-body-buffer-size,omitempty"`
+
+	// Defines a timeout for reading client request body, in seconds
+	// http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_timeout
+	ClientBodyTimeout int `json:"client-body-timeout,omitempty"`
+
+	// DisableAccessLog disables the Access Log globally from NGINX ingress controller
+	//http://nginx.org/en/docs/http/ngx_http_log_module.html
+	DisableAccessLog bool `json:"disable-access-log,omitempty"`
+
+	// DisableIpv6DNS disables IPv6 for nginx resolver
+	DisableIpv6DNS bool `json:"disable-ipv6-dns"`
+
+	// DisableIpv6 disable listening on ipv6 address
+	DisableIpv6 bool `json:"disable-ipv6,omitempty"`
+
+	// EnableUnderscoresInHeaders enables underscores in header names
+	// http://nginx.org/en/docs/http/ngx_http_core_module.html#underscores_in_headers
+	// By default this is disabled
+	EnableUnderscoresInHeaders bool `json:"enable-underscores-in-headers"`
+
+	// IgnoreInvalidHeaders set if header fields with invalid names should be ignored
+	// http://nginx.org/en/docs/http/ngx_http_core_module.html#ignore_invalid_headers
+	// By default this is enabled
+	IgnoreInvalidHeaders bool `json:"ignore-invalid-headers"`
+
+	// RetryNonIdempotent since 1.9.13 NGINX will not retry non-idempotent requests (POST, LOCK, PATCH)
+	// in case of an error. The previous behavior can be restored using the value true
+	RetryNonIdempotent bool `json:"retry-non-idempotent"`
+
+	// http://nginx.org/en/docs/ngx_core_module.html#error_log
+	// Configures logging level [debug | info | notice | warn | error | crit | alert | emerg]
+	// Log levels above are listed in the order of increasing severity
+	ErrorLogLevel string `json:"error-log-level,omitempty"`
+
+	// https://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_field_size
+	// HTTP2MaxFieldSize Limits the maximum size of an HPACK-compressed request header field
+	HTTP2MaxFieldSize string `json:"http2-max-field-size,omitempty"`
+
+	// https://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_header_size
+	// HTTP2MaxHeaderSize Limits the maximum size of the entire request header list after HPACK decompression
+	HTTP2MaxHeaderSize string `json:"http2-max-header-size,omitempty"`
+
+	// Enables or disables the header HSTS in servers running SSL
+	HSTS bool `json:"hsts,omitempty"`
+
+	// Enables or disables the use of HSTS in all the subdomains of the servername
+	// Default: true
+	HSTSIncludeSubdomains bool `json:"hsts-include-subdomains,omitempty"`
+
+	// HTTP Strict Transport Security (often abbreviated as HSTS) is a security feature (HTTP header)
+	// that tell browsers that it should only be communicated with using HTTPS, instead of using HTTP.
+	// https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security
+	// max-age is the time, in seconds, that the browser should remember that this site is only to be
+	// accessed using HTTPS.
+	HSTSMaxAge string `json:"hsts-max-age,omitempty"`
+
+	// Enables or disables the preload attribute in HSTS feature
+	HSTSPreload bool `json:"hsts-preload,omitempty"`
+
+	// Time during which a keep-alive client connection will stay open on the server side.
+	// The zero value disables keep-alive client connections
+	// http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout
+	KeepAlive int `json:"keep-alive,omitempty"`
+
+	// Sets the maximum number of requests that can be served through one keep-alive connection.
+	// http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests
+	KeepAliveRequests int `json:"keep-alive-requests,omitempty"`
+
+	// LargeClientHeaderBuffers Sets the maximum number and size of buffers used for reading
+	// large client request header.
+	// http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers
+	// Default: 4 8k
+	LargeClientHeaderBuffers string `json:"large-client-header-buffers"`
+
+	// Enable json escaping
+	// http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format
+	LogFormatEscapeJSON bool `json:"log-format-escape-json,omitempty"`
+
+	// Customize upstream log_format
+	// http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format
+	LogFormatUpstream string `json:"log-format-upstream,omitempty"`
+
+	// Customize stream log_format
+	// http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format
+	LogFormatStream string `json:"log-format-stream,omitempty"`
+
+	// If disabled, a worker process will accept one new connection at a time.
+	// Otherwise, a worker process will accept all new connections at a time.
+	// http://nginx.org/en/docs/ngx_core_module.html#multi_accept
+	// Default: true
+	EnableMultiAccept bool `json:"enable-multi-accept,omitempty"`
+
+	// Maximum number of simultaneous connections that can be opened by each worker process
+	// http://nginx.org/en/docs/ngx_core_module.html#worker_connections
+	MaxWorkerConnections int `json:"max-worker-connections,omitempty"`
+
+	// Sets the bucket size for the map variables hash tables.
+	// Default value depends on the processor’s cache line size.
+	// http://nginx.org/en/docs/http/ngx_http_map_module.html#map_hash_bucket_size
+	MapHashBucketSize int `json:"map-hash-bucket-size,omitempty"`
+
+	// NginxStatusIpv4Whitelist has the list of cidr that are allowed to access
+	// the /nginx_status endpoint of the "_" server
+	NginxStatusIpv4Whitelist []string `json:"nginx-status-ipv4-whitelist,omitempty"`
+	NginxStatusIpv6Whitelist []string `json:"nginx-status-ipv6-whitelist,omitempty"`
+
+	// If UseProxyProtocol is enabled ProxyRealIPCIDR defines the default the IP/network address
+	// of your external load balancer
+	ProxyRealIPCIDR []string `json:"proxy-real-ip-cidr,omitempty"`
+
+	// Sets the name of the configmap that contains the headers to pass to the backend
+	ProxySetHeaders string `json:"proxy-set-headers,omitempty"`
+
+	// Maximum size of the server names hash tables used in server names, map directive’s values,
+	// MIME types, names of request header strings, etcd.
+	// http://nginx.org/en/docs/hash.html
+	// http://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_max_size
+	ServerNameHashMaxSize int `json:"server-name-hash-max-size,omitempty"`
+
+	// Size of the bucket for the server names hash tables
+	// http://nginx.org/en/docs/hash.html
+	// http://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_bucket_size
+	ServerNameHashBucketSize int `json:"server-name-hash-bucket-size,omitempty"`
+
+	// Size of the bucket for the proxy headers hash tables
+	// http://nginx.org/en/docs/hash.html
+	// https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_headers_hash_max_size
+	ProxyHeadersHashMaxSize int `json:"proxy-headers-hash-max-size,omitempty"`
+
+	// Maximum size of the bucket for the proxy headers hash tables
+	// http://nginx.org/en/docs/hash.html
+	// https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_headers_hash_bucket_size
+	ProxyHeadersHashBucketSize int `json:"proxy-headers-hash-bucket-size,omitempty"`
+
+	// Enables or disables emitting nginx version in error messages and in the “Server” response header field.
+	// http://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens
+	// Default: true
+	ShowServerTokens bool `json:"server-tokens"`
+
+	// Enabled ciphers list to enabled. The ciphers are specified in the format understood by
+	// the OpenSSL library
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ciphers
+	SSLCiphers string `json:"ssl-ciphers,omitempty"`
+
+	// Specifies a curve for ECDHE ciphers.
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ecdh_curve
+	SSLECDHCurve string `json:"ssl-ecdh-curve,omitempty"`
+
+	// The secret that contains Diffie-Hellman key to help with "Perfect Forward Secrecy"
+	// https://wiki.openssl.org/index.php/Diffie-Hellman_parameters
+	// https://wiki.mozilla.org/Security/Server_Side_TLS#DHE_handshake_and_dhparam
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam
+	SSLDHParam string `json:"ssl-dh-param,omitempty"`
+
+	// SSL enabled protocols to use
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols
+	SSLProtocols string `json:"ssl-protocols,omitempty"`
+
+	// Enables or disables the use of shared SSL cache among worker processes.
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache
+	SSLSessionCache bool `json:"ssl-session-cache,omitempty"`
+
+	// Size of the SSL shared cache between all worker processes.
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache
+	SSLSessionCacheSize string `json:"ssl-session-cache-size,omitempty"`
+
+	// Enables or disables session resumption through TLS session tickets.
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets
+	SSLSessionTickets bool `json:"ssl-session-tickets,omitempty"`
+
+	// Sets the secret key used to encrypt and decrypt TLS session tickets.
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets
+	// By default, a randomly generated key is used.
+	// Example: openssl rand 80 | openssl enc -A -base64
+	SSLSessionTicketKey string `json:"ssl-session-ticket-key,omitempty"`
+
+	// Time during which a client may reuse the session parameters stored in a cache.
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout
+	SSLSessionTimeout string `json:"ssl-session-timeout,omitempty"`
+
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_buffer_size
+	// Sets the size of the buffer used for sending data.
+	// 4k helps NGINX to improve TLS Time To First Byte (TTTFB)
+	// https://www.igvita.com/2013/12/16/optimizing-nginx-tls-time-to-first-byte/
+	SSLBufferSize string `json:"ssl-buffer-size,omitempty"`
+
+	// Enables or disables the use of the PROXY protocol to receive client connection
+	// (real IP address) information passed through proxy servers and load balancers
+	// such as HAproxy and Amazon Elastic Load Balancer (ELB).
+	// https://www.nginx.com/resources/admin-guide/proxy-protocol/
+	UseProxyProtocol bool `json:"use-proxy-protocol,omitempty"`
+
+	// When use-proxy-protocol is enabled, sets the maximum time the connection handler will wait
+	// to receive proxy headers.
+	// Example '60s'
+	ProxyProtocolHeaderTimeout time.Duration `json:"proxy-protocol-header-timeout,omitempty"`
+
+	// Enables or disables the use of the nginx module that compresses responses using the "gzip" method
+	// http://nginx.org/en/docs/http/ngx_http_gzip_module.html
+	UseGzip bool `json:"use-gzip,omitempty"`
+
+	// Enables or disables the use of the nginx geoip module that creates variables with values depending on the client IP
+	// http://nginx.org/en/docs/http/ngx_http_geoip_module.html
+	UseGeoIP bool `json:"use-geoip,omitempty"`
+
+	// Enables or disables the use of the NGINX Brotli Module for compression
+	// https://github.com/google/ngx_brotli
+	EnableBrotli bool `json:"enable-brotli,omitempty"`
+
+	// Brotli Compression Level that will be used
+	BrotliLevel int `json:"brotli-level,omitempty"`
+
+	// MIME Types that will be compressed on-the-fly using Brotli module
+	BrotliTypes string `json:"brotli-types,omitempty"`
+
+	// Enables or disables the HTTP/2 support in secure connections
+	// http://nginx.org/en/docs/http/ngx_http_v2_module.html
+	// Default: true
+	UseHTTP2 bool `json:"use-http2,omitempty"`
+
+	// gzip Compression Level that will be used
+	GzipLevel int `json:"gzip-level,omitempty"`
+
+	// MIME types in addition to "text/html" to compress. The special value “*” matches any MIME type.
+	// Responses with the “text/html” type are always compressed if UseGzip is enabled
+	GzipTypes string `json:"gzip-types,omitempty"`
+
+	// Defines the number of worker processes. By default auto means number of available CPU cores
+	// http://nginx.org/en/docs/ngx_core_module.html#worker_processes
+	WorkerProcesses string `json:"worker-processes,omitempty"`
+
+	// Defines a timeout for a graceful shutdown of worker processes
+	// http://nginx.org/en/docs/ngx_core_module.html#worker_shutdown_timeout
+	WorkerShutdownTimeout string `json:"worker-shutdown-timeout,omitempty"`
+
+	// Defines the load balancing algorithm to use. The deault is round-robin
+	LoadBalanceAlgorithm string `json:"load-balance,omitempty"`
+
+	// Sets the bucket size for the variables hash table.
+	// http://nginx.org/en/docs/http/ngx_http_map_module.html#variables_hash_bucket_size
+	VariablesHashBucketSize int `json:"variables-hash-bucket-size,omitempty"`
+
+	// Sets the maximum size of the variables hash table.
+	// http://nginx.org/en/docs/http/ngx_http_map_module.html#variables_hash_max_size
+	VariablesHashMaxSize int `json:"variables-hash-max-size,omitempty"`
+
+	// Activates the cache for connections to upstream servers.
+	// The connections parameter sets the maximum number of idle keepalive connections to
+	// upstream servers that are preserved in the cache of each worker process. When this
+	// number is exceeded, the least recently used connections are closed.
+	// http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
+	// Default: 32
+	UpstreamKeepaliveConnections int `json:"upstream-keepalive-connections,omitempty"`
+
+	// Sets the maximum size of the variables hash table.
+	// http://nginx.org/en/docs/http/ngx_http_map_module.html#variables_hash_max_size
+	LimitConnZoneVariable string `json:"limit-conn-zone-variable,omitempty"`
+
+	// Sets the timeout between two successive read or write operations on client or proxied server connections.
+	// If no data is transmitted within this time, the connection is closed.
+	// http://nginx.org/en/docs/stream/ngx_stream_proxy_module.html#proxy_timeout
+	ProxyStreamTimeout string `json:"proxy-stream-timeout,omitempty"`
+
+	// Sets the number of datagrams expected from the proxied server in response
+	// to the client request if the UDP protocol is used.
+	// http://nginx.org/en/docs/stream/ngx_stream_proxy_module.html#proxy_responses
+	// Default: 1
+	ProxyStreamResponses int `json:"proxy-stream-responses,omitempty"`
+
+	// Sets the ipv4 addresses on which the server will accept requests.
+	BindAddressIpv4 []string `json:"bind-address-ipv4,omitempty"`
+
+	// Sets the ipv6 addresses on which the server will accept requests.
+	BindAddressIpv6 []string `json:"bind-address-ipv6,omitempty"`
+
+	// Sets whether to use incoming X-Forwarded headers.
+	UseForwardedHeaders bool `json:"use-forwarded-headers"`
+
+	// Sets the header field for identifying the originating IP address of a client
+	// Default is X-Forwarded-For
+	ForwardedForHeader string `json:"forwarded-for-header,omitempty"`
+
+	// Append the remote address to the X-Forwarded-For header instead of replacing it
+	// Default: false
+	ComputeFullForwardedFor bool `json:"compute-full-forwarded-for,omitempty"`
+
+	// If the request does not have a request-id, should we generate a random value?
+	// Default: true
+	GenerateRequestId bool `json:"generate-request-id,omitempty"`
+
+	// Adds an X-Original-Uri header with the original request URI to the backend request
+	// Default: true
+	ProxyAddOriginalUriHeader bool `json:"proxy-add-original-uri-header"`
+
+	// EnableOpentracing enables the nginx Opentracing extension
+	// https://github.com/rnburn/nginx-opentracing
+	// By default this is disabled
+	EnableOpentracing bool `json:"enable-opentracing"`
+
+	// ZipkinCollectorHost specifies the host to use when uploading traces
+	ZipkinCollectorHost string `json:"zipkin-collector-host"`
+
+	// ZipkinCollectorPort specifies the port to use when uploading traces
+	ZipkinCollectorPort int `json:"zipkin-collector-port"`
+
+	// ZipkinServiceName specifies the service name to use for any traces created
+	// Default: nginx
+	ZipkinServiceName string `json:"zipkin-service-name"`
+
+	// ZipkinSampleRate specifies sampling rate for traces
+	// Default: 1.0
+	ZipkinSampleRate float32 `json:"zipkin-sample-rate"`
+
+	// JaegerCollectorHost specifies the host to use when uploading traces
+	JaegerCollectorHost string `json:"jaeger-collector-host"`
+
+	// JaegerCollectorPort specifies the port to use when uploading traces
+	JaegerCollectorPort int `json:"jaeger-collector-port"`
+
+	// JaegerServiceName specifies the service name to use for any traces created
+	// Default: nginx
+	JaegerServiceName string `json:"jaeger-service-name"`
+
+	// JaegerSamplerType specifies the sampler to be used when sampling traces.
+	// The available samplers are: const, probabilistic, ratelimiting, remote
+	// Default: const
+	JaegerSamplerType string `json:"jaeger-sampler-type"`
+
+	// JaegerSamplerParam specifies the argument to be passed to the sampler constructor
+	// Default: 1
+	JaegerSamplerParam string `json:"jaeger-sampler-param"`
+
+	// MainSnippet adds custom configuration to the main section of the nginx configuration
+	MainSnippet string `json:"main-snippet"`
+
+	// HTTPSnippet adds custom configuration to the http section of the nginx configuration
+	HTTPSnippet string `json:"http-snippet"`
+
+	// ServerSnippet adds custom configuration to all the servers in the nginx configuration
+	ServerSnippet string `json:"server-snippet"`
+
+	// LocationSnippet adds custom configuration to all the locations in the nginx configuration
+	LocationSnippet string `json:"location-snippet"`
+
+	// HTTPRedirectCode sets the HTTP status code to be used in redirects.
+	// Supported codes are 301,302,307 and 308
+	// Default: 308
+	HTTPRedirectCode int `json:"http-redirect-code"`
+
+	// ReusePort instructs NGINX to create an individual listening socket for
+	// each worker process (using the SO_REUSEPORT socket option), allowing a
+	// kernel to distribute incoming connections between worker processes
+	// Default: true
+	ReusePort bool `json:"reuse-port"`
+
+	// HideHeaders sets additional header that will not be passed from the upstream
+	// server to the client response
+	// Default: empty
+	HideHeaders []string `json:"hide-headers"`
+
+	// LimitReqStatusCode Sets the status code to return in response to rejected requests.
+	// http://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_status
+	// Default: 503
+	LimitReqStatusCode int `json:"limit-req-status-code"`
+
+	// EnableSyslog enables the configuration for remote logging in NGINX
+	EnableSyslog bool `json:"enable-syslog"`
+	// SyslogHost FQDN or IP address where the logs should be sent
+	SyslogHost string `json:"syslog-host"`
+	// SyslogPort port
+	SyslogPort int `json:"syslog-port"`
+
+	// NoTLSRedirectLocations is a comma-separated list of locations
+	// that should not get redirected to TLS
+	NoTLSRedirectLocations string `json:"no-tls-redirect-locations"`
+
+	// NoAuthLocations is a comma-separated list of locations that
+	// should not get authenticated
+	NoAuthLocations string `json:"no-auth-locations"`
+
+	// DisableLuaRestyWAF disables lua-resty-waf globally regardless
+	// of whether there's an ingress that has enabled the WAF using annotation
+	DisableLuaRestyWAF bool `json:"disable-lua-resty-waf"`
+
+	// EnableInfluxDB enables the nginx InfluxDB extension
+	// http://github.com/influxdata/nginx-influxdb-module/
+	// By default this is disabled
+	EnableInfluxDB bool `json:"enable-influxdb"`
+
+	// Checksum contains a checksum of the configmap configuration
+	Checksum string `json:"-"`
+}
+
+// NewDefault returns the default nginx configuration
+func NewDefault() Configuration {
+	defIPCIDR := make([]string, 0)
+	defBindAddress := make([]string, 0)
+	defNginxStatusIpv4Whitelist := make([]string, 0)
+	defNginxStatusIpv6Whitelist := make([]string, 0)
+
+	defIPCIDR = append(defIPCIDR, "0.0.0.0/0")
+	defNginxStatusIpv4Whitelist = append(defNginxStatusIpv4Whitelist, "127.0.0.1")
+	defNginxStatusIpv6Whitelist = append(defNginxStatusIpv6Whitelist, "::1")
+	defProxyDeadlineDuration := time.Duration(5) * time.Second
+
+	cfg := Configuration{
+		AllowBackendServerHeader:   false,
+		AccessLogPath:              "/var/log/nginx/access.log",
+		WorkerCpuAffinity:          "",
+		ErrorLogPath:               "/var/log/nginx/error.log",
+		BrotliLevel:                4,
+		BrotliTypes:                brotliTypes,
+		ClientHeaderBufferSize:     "1k",
+		ClientHeaderTimeout:        60,
+		ClientBodyBufferSize:       "8k",
+		ClientBodyTimeout:          60,
+		EnableDynamicTLSRecords:    true,
+		EnableUnderscoresInHeaders: false,
+		ErrorLogLevel:              errorLevel,
+		UseForwardedHeaders:        true,
+		ForwardedForHeader:         "X-Forwarded-For",
+		ComputeFullForwardedFor:    false,
+		ProxyAddOriginalUriHeader:  true,
+		GenerateRequestId:          true,
+		HTTP2MaxFieldSize:          "4k",
+		HTTP2MaxHeaderSize:         "16k",
+		HTTPRedirectCode:           308,
+		HSTS:                       true,
+		HSTSIncludeSubdomains:      true,
+		HSTSMaxAge:                 hstsMaxAge,
+		HSTSPreload:                false,
+		IgnoreInvalidHeaders:       true,
+		GzipLevel:                  5,
+		GzipTypes:                  gzipTypes,
+		KeepAlive:                  75,
+		KeepAliveRequests:          100,
+		LargeClientHeaderBuffers:   "4 8k",
+		LogFormatEscapeJSON:        false,
+		LogFormatStream:            logFormatStream,
+		LogFormatUpstream:          logFormatUpstream,
+		EnableMultiAccept:          true,
+		MaxWorkerConnections:       16384,
+		MapHashBucketSize:          64,
+		NginxStatusIpv4Whitelist:   defNginxStatusIpv4Whitelist,
+		NginxStatusIpv6Whitelist:   defNginxStatusIpv6Whitelist,
+		ProxyRealIPCIDR:            defIPCIDR,
+		ProxyProtocolHeaderTimeout: defProxyDeadlineDuration,
+		ServerNameHashMaxSize:      1024,
+		ProxyHeadersHashMaxSize:    512,
+		ProxyHeadersHashBucketSize: 64,
+		ProxyStreamResponses:       1,
+		ReusePort:                  true,
+		ShowServerTokens:           true,
+		SSLBufferSize:              sslBufferSize,
+		SSLCiphers:                 sslCiphers,
+		SSLECDHCurve:               "auto",
+		SSLProtocols:               sslProtocols,
+		SSLSessionCache:            true,
+		SSLSessionCacheSize:        sslSessionCacheSize,
+		SSLSessionTickets:          true,
+		SSLSessionTimeout:          sslSessionTimeout,
+		EnableBrotli:               false,
+		UseGzip:                    true,
+		UseGeoIP:                   true,
+		WorkerProcesses:            strconv.Itoa(runtime.NumCPU()),
+		WorkerShutdownTimeout:      "10s",
+		LoadBalanceAlgorithm:       defaultLoadBalancerAlgorithm,
+		VariablesHashBucketSize:    128,
+		VariablesHashMaxSize:       2048,
+		UseHTTP2:                   true,
+		ProxyStreamTimeout:         "600s",
+		Backend: defaults.Backend{
+			ProxyBodySize:          bodySize,
+			ProxyConnectTimeout:    5,
+			ProxyReadTimeout:       60,
+			ProxySendTimeout:       60,
+			ProxyBufferSize:        "4k",
+			ProxyCookieDomain:      "off",
+			ProxyCookiePath:        "off",
+			ProxyNextUpstream:      "error timeout",
+			ProxyNextUpstreamTries: 3,
+			ProxyRequestBuffering:  "on",
+			ProxyRedirectFrom:      "off",
+			ProxyRedirectTo:        "off",
+			SSLRedirect:            true,
+			CustomHTTPErrors:       []int{},
+			WhitelistSourceRange:   []string{},
+			SkipAccessLogURLs:      []string{},
+			LimitRate:              0,
+			LimitRateAfter:         0,
+			ProxyBuffering:         "off",
+		},
+		UpstreamKeepaliveConnections: 32,
+		LimitConnZoneVariable:        defaultLimitConnZoneVariable,
+		BindAddressIpv4:              defBindAddress,
+		BindAddressIpv6:              defBindAddress,
+		ZipkinCollectorPort:          9411,
+		ZipkinServiceName:            "nginx",
+		ZipkinSampleRate:             1.0,
+		JaegerCollectorPort:          6831,
+		JaegerServiceName:            "nginx",
+		JaegerSamplerType:            "const",
+		JaegerSamplerParam:           "1",
+		LimitReqStatusCode:           503,
+		SyslogPort:                   514,
+		NoTLSRedirectLocations:       "/.well-known/acme-challenge",
+		NoAuthLocations:              "/.well-known/acme-challenge",
+	}
+
+	if glog.V(5) {
+		cfg.ErrorLogLevel = "debug"
+	}
+
+	return cfg
 }
 
 // BuildLogFormatUpstream format the log_format upstream using
@@ -40,7 +664,6 @@ func (cfg Configuration) BuildLogFormatUpstream() string {
 	return cfg.LogFormatUpstream
 }
 
-*/
 // TemplateConfig contains the nginx configuration to render the file nginx.conf
 type TemplateConfig struct {
 	ProxySetHeaders             map[string]string
@@ -63,6 +686,7 @@ type TemplateConfig struct {
 	ListenPorts                 *ListenPorts
 	PublishService              *apiv1.Service
 	DynamicConfigurationEnabled bool
+	DynamicCertificatesEnabled  bool
 	DisableLua                  bool
 }
 

--- a/internal/ingress/defaults/main.go
+++ b/internal/ingress/defaults/main.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaults
+
+import "net"
+
+// TODO: Remove this file in next CRD PR
+// Backend defines the mandatory configuration that an Ingress controller must provide
+// The reason of this requirements is the annotations are generic. If some implementation do not supports
+// one or more annotations it just can provides defaults
+type Backend struct {
+	// AppRoot contains the AppRoot for apps that doesn't exposes its content in the 'root' context
+	AppRoot string `json:"app-root"`
+
+	// enables which HTTP codes should be passed for processing with the error_page directive
+	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_intercept_errors
+	// http://nginx.org/en/docs/http/ngx_http_core_module.html#error_page
+	// By default this is disabled
+	CustomHTTPErrors []int `json:"custom-http-errors,-"`
+
+	// http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
+	// Sets the maximum allowed size of the client request body
+	ProxyBodySize string `json:"proxy-body-size"`
+
+	// Defines a timeout for establishing a connection with a proxied server.
+	// It should be noted that this timeout cannot usually exceed 75 seconds.
+	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_connect_timeout
+	ProxyConnectTimeout int `json:"proxy-connect-timeout"`
+
+	// Timeout in seconds for reading a response from the proxied server. The timeout is set only between
+	// two successive read operations, not for the transmission of the whole response
+	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_read_timeout
+	ProxyReadTimeout int `json:"proxy-read-timeout"`
+
+	// Timeout in seconds for transmitting a request to the proxied server. The timeout is set only between
+	// two successive write operations, not for the transmission of the whole request.
+	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_send_timeout
+	ProxySendTimeout int `json:"proxy-send-timeout"`
+
+	// Sets the size of the buffer used for reading the first part of the response received from the
+	// proxied server. This part usually contains a small response header.
+	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size)
+	ProxyBufferSize string `json:"proxy-buffer-size"`
+
+	// Sets a text that should be changed in the path attribute of the “Set-Cookie” header fields of
+	// a proxied server response.
+	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cookie_path
+	ProxyCookiePath string `json:"proxy-cookie-path"`
+
+	// Sets a text that should be changed in the domain attribute of the “Set-Cookie” header fields
+	// of a proxied server response.
+	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cookie_domain
+	ProxyCookieDomain string `json:"proxy-cookie-domain"`
+
+	// Specifies in which cases a request should be passed to the next server.
+	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream
+	ProxyNextUpstream string `json:"proxy-next-upstream"`
+
+	// Limits the number of possible tries for passing a request to the next server.
+	// https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream_tries
+	ProxyNextUpstreamTries int `json:"proxy-next-upstream-tries"`
+
+	// Sets the original text that should be changed in the "Location" and "Refresh" header fields of a proxied server response.
+	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_redirect
+	// Default: off
+	ProxyRedirectFrom string `json:"proxy-redirect-from"`
+
+	// Sets the replacement text that should be changed in the "Location" and "Refresh" header fields of a proxied server response.
+	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_redirect
+	// Default: ""
+	ProxyRedirectTo string `json:"proxy-redirect-to"`
+
+	// Enables or disables buffering of a client request body.
+	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_request_buffering
+	ProxyRequestBuffering string `json:"proxy-request-buffering"`
+
+	// Name server/s used to resolve names of upstream servers into IP addresses.
+	// The file /etc/resolv.conf is used as DNS resolution configuration.
+	Resolver []net.IP
+
+	// SkipAccessLogURLs sets a list of URLs that should not appear in the NGINX access log
+	// This is useful with urls like `/health` or `health-check` that make "complex" reading the logs
+	// By default this list is empty
+	SkipAccessLogURLs []string `json:"skip-access-log-urls,-"`
+
+	// Enables or disables the redirect (301) to the HTTPS port
+	SSLRedirect bool `json:"ssl-redirect"`
+
+	// Enables or disables the redirect (301) to the HTTPS port even without TLS cert
+	// This is useful if doing SSL offloading outside of cluster eg AWS ELB
+	ForceSSLRedirect bool `json:"force-ssl-redirect"`
+
+	// Enables or disables the specification of port in redirects
+	// Default: false
+	UsePortInRedirects bool `json:"use-port-in-redirects"`
+
+	// Number of unsuccessful attempts to communicate with the server that should happen in the
+	// duration set by the fail_timeout parameter to consider the server unavailable
+	// http://nginx.org/en/docs/http/ngx_http_upstream_module.html#upstream
+	// Default: 0, ie use platform liveness probe
+	UpstreamMaxFails int `json:"upstream-max-fails"`
+
+	// Time during which the specified number of unsuccessful attempts to communicate with
+	// the server should happen to consider the server unavailable
+	// http://nginx.org/en/docs/http/ngx_http_upstream_module.html#upstream
+	// Default: 0, ie use platform liveness probe
+	UpstreamFailTimeout int `json:"upstream-fail-timeout"`
+
+	// Enable stickiness by client-server mapping based on a NGINX variable, text or a combination of both.
+	// A consistent hashing method will be used which ensures only a few keys would be remapped to different
+	// servers on upstream group changes
+	// http://nginx.org/en/docs/http/ngx_http_upstream_module.html#hash
+	UpstreamHashBy string `json:"upstream-hash-by"`
+
+	// Let's us choose a load balancing algorithm per ingress
+	LoadBalancing string `json:"load-balance"`
+
+	// WhitelistSourceRange allows limiting access to certain client addresses
+	// http://nginx.org/en/docs/http/ngx_http_access_module.html
+	WhitelistSourceRange []string `json:"whitelist-source-range,-"`
+
+	// Limits the rate of response transmission to a client.
+	// The rate is specified in bytes per second. The zero value disables rate limiting.
+	// The limit is set per a request, and so if a client simultaneously opens two connections,
+	// the overall rate will be twice as much as the specified limit.
+	// http://nginx.org/en/docs/http/ngx_http_core_module.html#limit_rate
+	LimitRate int `json:"limit-rate"`
+
+	// Sets the initial amount after which the further transmission of a response to a client will be rate limited.
+	// http://nginx.org/en/docs/http/ngx_http_core_module.html#limit_rate_after
+	LimitRateAfter int `json:"limit-rate-after"`
+
+	// Enables or disables buffering of responses from the proxied server.
+	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering
+	ProxyBuffering string `json:"proxy-buffering"`
+}


### PR DESCRIPTION
Adds (most of) the default values for the new objects created. Reverts back config-map code, so that the review can be only that of the newly generated objects.